### PR TITLE
changed unicode to str for py3 switch

### DIFF
--- a/scourgify/cleaning.py
+++ b/scourgify/cleaning.py
@@ -180,7 +180,7 @@ def clean_upper(text,                           # type: Any
     if not isinstance(text, str):  # pragma: no cover
         text = str(text)
     # catch and convert fractions
-    text = unicodedata.normalize('NFKD', unicode(text))
+    text = unicodedata.normalize('NFKD', str(text))
     text = text.translate({8260: '/'})
 
     # evaluate string without commas (,) or ampersand (&) to determine if


### PR DESCRIPTION
Replaced `unicode` with `str` for Python3 support